### PR TITLE
docs(architecture): fix monorepo layer diagram and add architecture discussion

### DIFF
--- a/specs/1000/1001/1013.context.md
+++ b/specs/1000/1001/1013.context.md
@@ -73,3 +73,35 @@ Successfully completed Warm Storage (SATA) setup with automated scripts, health 
 - 🔧 Fully automated setup process
 - 📊 Comprehensive health monitoring
 - 📚 Complete documentation package
+
+## Architecture Discussion (2025-08-28)
+
+### Questions Reviewed from Spec 1003 (Monorepo Structure)
+
+**Q1: Why do `brokers` and `domain` exist in `libs/`?**
+
+**Answer**: This is correct according to Nx monorepo architecture with DDD:
+- `libs/brokers/`: Contains broker integration libraries (Creon, KIS, Binance, Upbit) as shared libraries that can be imported by multiple services
+- `libs/domain/`: Contains business domain logic following DDD principles - centralized and reusable across services
+
+This separation follows the dependency rule: apps can depend on libs, but not vice versa.
+
+**Q2: Market Data Collector and Notification Service placement inconsistency**
+
+**Issue Identified**: In the System Architecture Layers diagram, these services are shown in the Integration Layer, but in the Workspace Structure, they're in `apps/`.
+
+**Resolution**: 
+- These should be standalone microservices in `apps/` (current workspace structure is correct)
+- The architecture diagram should be updated to show them in the Business Layer
+- They use integration libraries from `libs/brokers/` but are themselves business services
+
+**Q3: No `src/` directory at project root**
+
+**Answer**: This is standard for Nx monorepo structure:
+- Each app and lib has its own `src/` directory internally
+- Root level contains only workspace-wide configuration
+- Documentation folders (`specs/`, `context/`) can optionally be moved to `docs/` for better organization
+
+### Action Items
+- ✅ Document architecture clarifications
+- ⏳ Update spec 1003 to fix architecture layer diagram

--- a/specs/1000/1003/spec.md
+++ b/specs/1000/1003/spec.md
@@ -22,7 +22,7 @@ reviewer: '' # Who should review (optional)
 
 # === TRACKING ===
 created: '2025-08-24' # YYYY-MM-DD
-updated: '2025-08-24' # YYYY-MM-DD
+updated: '2025-08-28' # YYYY-MM-DD
 due_date: '' # YYYY-MM-DD (optional)
 estimated_hours: 12 # Time estimate in hours
 actual_hours: 0 # Time spent so far
@@ -88,13 +88,15 @@ Establish a comprehensive monorepo structure using Nx workspace to manage all JT
 ├────────────────┬────────────────┬────────────────┬───────────────┤
 │    Strategy    │   Risk         │    Portfolio   │    Order      │
 │    Engine      │   Management   │    Tracker     │    Execution  │
-└────────────────┴────────────────┴────────────────┴───────────────┘
+├────────────────┴────────────────┴────────────────┴───────────────┤
+│        Market Data Collector    │    Notification Service        │
+└──────────────────────────────────────────────────────────────────┘
                                ↓
 ┌──────────────────────────────────────────────────────────────────┐
 │                   Integration Layer                              │
-├───────────────────────────────┬──────────────────────────────────┤
-│     Market Data Collector     │     Notification Service         │
-└───────────────────────────────┴──────────────────────────────────┘
+│            (Broker Libraries & Infrastructure Utilities)         │
+│         libs/brokers/* | libs/infrastructure/*                   │
+└──────────────────────────────────────────────────────────────────┘
                                ↓
 ┌──────────────────────────────────────────────────────────────────┐
 │                    Messaging Layer                               │
@@ -119,9 +121,16 @@ Establish a comprehensive monorepo structure using Nx workspace to manage all JT
 ```
 
 #### Workspace Structure
+
+**Note**: The workspace follows Nx conventions where:
+- `apps/` contains standalone microservices and applications
+- `libs/` contains shared libraries and reusable modules
+- Each service in `apps/` can import libraries from `libs/`
+- No top-level `src/` directory - each app/lib has its own `src/`
+
 ```
 jts/
-├── apps/                           # Applications
+├── apps/                           # Applications (Standalone Microservices)
 │   ├── api-gateway/               # Express.js API Gateway
 │   ├── web-app/                   # Next.js Frontend
 │   ├── strategy-engine/           # NestJS Strategy Service
@@ -130,7 +139,7 @@ jts/
 │   ├── market-data-collector/     # NestJS Market Data Service
 │   ├── notification-service/      # NestJS Notification Service
 │   └── creon-bridge/             # Windows COM Bridge Service
-├── libs/                          # Shared Libraries
+├── libs/                          # Shared Libraries (Reusable Modules)
 │   ├── shared/
 │   │   ├── dto/                  # Data Transfer Objects
 │   │   ├── interfaces/           # TypeScript Interfaces
@@ -1089,3 +1098,4 @@ For comprehensive system architecture and implementation details, see:
 
 - **2025-08-24**: Feature specification created and documented
 - **2025-08-27**: Integrated comprehensive architecture with DDD and layered design
+- **2025-08-28**: Fixed architecture layer diagram - moved Market Data Collector and Notification Service to Business Layer, clarified Integration Layer as libraries only


### PR DESCRIPTION
## Summary
- Fixed architecture layer diagram inconsistency in monorepo structure specification
- Added comprehensive architecture discussion documenting common questions about Nx workspace structure

## Technical Details
- **File**: `specs/1000/1003/spec.md`
  - Moved Market Data Collector and Notification Service from Integration Layer to Business Layer in architecture diagram
  - Updated Integration Layer description to clarify it contains only shared libraries (`libs/brokers/*`, `libs/infrastructure/*`)
  - Added workspace conventions note explaining `apps/` vs `libs/` structure
  - Updated metadata `updated` field to 2025-08-28
- **File**: `specs/1000/1001/1013.context.md`  
  - Added "Architecture Discussion" section with Q&A addressing:
    - Why `brokers` and `domain` exist in `libs/` (correct DDD pattern)
    - Service placement inconsistency (resolved by moving to Business Layer)
    - No `src/` directory concern (standard Nx convention)

## Testing
- Architecture diagram now correctly shows services as Business Layer applications that use Integration Layer libraries
- Workspace structure documentation aligns with actual Nx monorepo conventions
- Context file preserves architectural decisions for future reference

## Breaking Changes
None - documentation updates only

🤖 Generated with [Claude Code](https://claude.ai/code)