### PR TITLE
docs(spec): update message queue spec with existing infrastructure configuration

### DIFF
--- a/specs/1000/1006/1006.spec.md
+++ b/specs/1000/1006/1006.spec.md
@@ -50,16 +50,17 @@ Implement a comprehensive Apache Kafka cluster configuration for the JTS automat
 
 ## Acceptance Criteria
 
-- [ ] **Kafka Cluster Configuration**: Production-ready Kafka cluster with Zookeeper, optimized for trading workloads with proper resource allocation and storage configuration
-- [ ] **Topic Design & Partitioning**: Well-architected topic structure with strategic partitioning for market data, order events, strategy signals, and system notifications
+- [ ] **Kafka Cluster Configuration**: Production-ready 3-broker Kafka cluster with Zookeeper, optimized for trading workloads with proper resource allocation and 4TB SSD storage configuration
+- [ ] **Schema Registry Integration**: Confluent Schema Registry deployment with backward compatibility for schema evolution
+- [ ] **Topic Design & Partitioning**: Well-architected topic structure with strategic partitioning for Korean (KRX) and cryptocurrency markets, order events, strategy signals, and system notifications
 - [ ] **Protocol Buffers Integration**: Complete Protocol Buffers schema definitions with code generation for TypeScript and efficient binary serialization
-- [ ] **Producer Patterns**: High-performance producer implementations with batching, compression, idempotent writes, and error handling strategies
+- [ ] **Producer Patterns**: High-performance producer implementations with batching, compression (LZ4), idempotent writes, and error handling strategies
 - [ ] **Consumer Patterns**: Robust consumer groups with offset management, rebalancing strategies, and parallel processing capabilities  
 - [ ] **Event Streaming Architecture**: Stream processing topology for real-time data transformation, aggregation, and event correlation
-- [ ] **Performance Optimization**: Kafka cluster tuned for sub-millisecond latency with proper memory allocation, I/O threading, and network configuration
-- [ ] **Monitoring & Observability**: Comprehensive metrics collection, alerting, and performance monitoring for message queuing infrastructure
-- [ ] **Schema Evolution**: Protocol Buffers schema versioning and backward compatibility management
-- [ ] **Development Tools**: Kafka admin tools, testing utilities, and local development environment setup
+- [ ] **Performance Optimization**: Kafka cluster tuned for sub-millisecond latency with JVM heap optimization (8GB per broker), kernel tuning, and network configuration
+- [ ] **Monitoring & Observability**: Kafka UI for visual monitoring, JMX metrics, Prometheus exporter integration, and comprehensive health checks
+- [ ] **Storage Migration Strategy**: Clear migration path from local storage to 4TB NVMe SSD with XFS filesystem optimization
+- [ ] **Development Tools**: Kafka admin tools, testing utilities, backup scripts, and local development environment setup
 
 ## Technical Approach
 
@@ -107,11 +108,15 @@ Design a highly scalable event streaming architecture that supports real-time tr
 #### 1. Kafka Cluster Configuration
 
 **High-Performance Setup:**
-- 3-node Kafka cluster for fault tolerance
-- XFS filesystem with dedicated 600GB LVM volume
-- 16 I/O threads and 8 network threads for optimal throughput
-- LZ4 compression for 40% reduction in network and storage usage
+- 3-broker Kafka cluster (kafka1, kafka2, kafka3) for fault tolerance
+- Initial deployment with local storage, migration path to 4TB NVMe SSD
+- XFS filesystem optimization on dedicated SSD volume (`/mnt/ssd4tb/kafka/`)
+- 8 I/O threads and 8 network threads per broker for optimal throughput
+- LZ4 compression for ~40% reduction in network and storage usage
 - 1GB log segments with 7-day retention for regulatory compliance
+- JVM heap optimization: 8GB per broker with G1GC for low-latency
+- Confluent Schema Registry for schema management
+- Kafka UI for visual cluster monitoring
 
 ```yaml
 # infrastructure/kafka/docker-compose.kafka.yml
@@ -136,125 +141,126 @@ services:
     ulimits:
       nofile: 65536
 
-  kafka-broker-1:
+  kafka1:
     image: confluentinc/cp-kafka:7.5.0
-    container_name: jts-kafka-1
-    restart: unless-stopped
+    hostname: kafka1
+    container_name: jts-kafka1
     depends_on:
       - zookeeper
     ports:
       - "9092:9092"
       - "19092:19092"
     volumes:
-      - /var/lib/kafka/broker-1:/var/kafka-logs
+      # Initial: ./data/kafka/kafka1:/var/lib/kafka/data
+      # Production: /mnt/ssd4tb/kafka/kafka1:/var/lib/kafka/data
+      - ./data/kafka/kafka1:/var/lib/kafka/data
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-      
-      # Listener Configuration
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-broker-1:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      
-      # Replication & Durability
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 3
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 3
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 2
-      KAFKA_MIN_IN_SYNC_REPLICAS: 2
-      KAFKA_DEFAULT_REPLICATION_FACTOR: 3
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
+      KAFKA_DELETE_TOPIC_ENABLE: 'true'
       
       # Performance Optimization
-      KAFKA_NUM_IO_THREADS: 16
       KAFKA_NUM_NETWORK_THREADS: 8
+      KAFKA_NUM_IO_THREADS: 8
       KAFKA_SOCKET_SEND_BUFFER_BYTES: 102400
       KAFKA_SOCKET_RECEIVE_BUFFER_BYTES: 102400
       KAFKA_SOCKET_REQUEST_MAX_BYTES: 104857600
       
       # Log Configuration
-      KAFKA_LOG_SEGMENT_BYTES: 1073741824  # 1GB segments
-      KAFKA_LOG_RETENTION_HOURS: 168       # 7 days
+      KAFKA_LOG_RETENTION_HOURS: 168  # 7 days
+      KAFKA_LOG_SEGMENT_BYTES: 1073741824  # 1GB
       KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS: 300000
-      KAFKA_LOG_CLEANUP_POLICY: delete
+      KAFKA_LOG_CLEANUP_POLICY: "delete"
+      KAFKA_COMPRESSION_TYPE: "lz4"
       
-      # Compression
-      KAFKA_COMPRESSION_TYPE: lz4
-      KAFKA_LOG_COMPRESSION_TYPE: lz4
-      
-      # Memory & GC
+      # JVM Settings (production: increase to "-Xmx8G -Xms8G")
       KAFKA_HEAP_OPTS: "-Xmx6G -Xms6G"
       KAFKA_JVM_PERFORMANCE_OPTS: "-XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35"
-      
-      # Monitoring
-      KAFKA_JMX_PORT: 19092
-      KAFKA_JMX_HOSTNAME: localhost
     ulimits:
       nofile: 65536
 
-  kafka-broker-2:
+  kafka2:
     image: confluentinc/cp-kafka:7.5.0
-    container_name: jts-kafka-2
-    restart: unless-stopped
+    hostname: kafka2
+    container_name: jts-kafka2
     depends_on:
       - zookeeper
     ports:
       - "9093:9093"
       - "19093:19093"
     volumes:
-      - /var/lib/kafka/broker-2:/var/kafka-logs
+      - ./data/kafka/kafka2:/var/lib/kafka/data
     environment:
       KAFKA_BROKER_ID: 2
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-broker-2:29093,PLAINTEXT_HOST://localhost:9093
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29093,PLAINTEXT_HOST://0.0.0.0:9093
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      # ... (same performance and durability settings as broker-1)
-      KAFKA_JMX_PORT: 19093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:29093,PLAINTEXT_HOST://localhost:9093
+      # ... (same settings as kafka1)
     ulimits:
       nofile: 65536
 
-  kafka-broker-3:
+  kafka3:
     image: confluentinc/cp-kafka:7.5.0
-    container_name: jts-kafka-3
-    restart: unless-stopped
+    hostname: kafka3
+    container_name: jts-kafka3
     depends_on:
       - zookeeper
     ports:
       - "9094:9094"
       - "19094:19094"
     volumes:
-      - /var/lib/kafka/broker-3:/var/kafka-logs
+      - ./data/kafka/kafka3:/var/lib/kafka/data
     environment:
       KAFKA_BROKER_ID: 3
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-broker-3:29094,PLAINTEXT_HOST://localhost:9094
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29094,PLAINTEXT_HOST://0.0.0.0:9094
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      # ... (same performance and durability settings as broker-1)
-      KAFKA_JMX_PORT: 19094
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:29094,PLAINTEXT_HOST://localhost:9094
+      # ... (same settings as kafka1)
     ulimits:
       nofile: 65536
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:7.5.0
+    hostname: schema-registry
+    container_name: jts-schema-registry
+    depends_on:
+      - kafka1
+      - kafka2
+      - kafka3
+    ports:
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'kafka1:29092,kafka2:29093,kafka3:29094'
+      SCHEMA_REGISTRY_KAFKASTORE_TOPIC_REPLICATION_FACTOR: 2
+      SCHEMA_REGISTRY_SCHEMA_COMPATIBILITY_LEVEL: "backward"
+    networks:
+      - jts-network
 
   kafka-ui:
     image: provectuslabs/kafka-ui:latest
     container_name: jts-kafka-ui
-    restart: unless-stopped
+    depends_on:
+      - kafka1
+      - kafka2
+      - kafka3
+      - schema-registry
     ports:
       - "8080:8080"
     environment:
-      KAFKA_CLUSTERS_0_NAME: jts-trading-cluster
-      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka-broker-1:29092,kafka-broker-2:29093,kafka-broker-3:29094
+      KAFKA_CLUSTERS_0_NAME: jts-cluster
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka1:29092,kafka2:29093,kafka3:29094
       KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
-    depends_on:
-      - kafka-broker-1
-      - kafka-broker-2
-      - kafka-broker-3
+      KAFKA_CLUSTERS_0_SCHEMAREGISTRY: http://schema-registry:8081
+    networks:
+      - jts-network
 
 networks:
-  default:
-    name: jts-kafka-network
+  jts-network:
     driver: bridge
 ```
 
@@ -264,158 +270,152 @@ networks:
 
 ```bash
 #!/bin/bash
-# scripts/kafka-setup/create-topics.sh
+# infrastructure/kafka/setup-topics.sh
 
 set -e
 
-KAFKA_BROKERS="localhost:9092,localhost:9093,localhost:9094"
-REPLICATION_FACTOR=3
-
 echo "Creating JTS trading system topics..."
 
-# Market Data Topics (High throughput, symbol-based partitioning)
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic market.price.ticks \
-  --partitions 24 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
-  --config retention.ms=604800000 \
-  --config segment.ms=3600000
-
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic market.orderbook.snapshots \
-  --partitions 16 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
+# Market Data Topics - High throughput with strategic partitioning
+# Korean stock market data (KRX)
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic market-data.krx.ticks \
+  --partitions 12 \
+  --replication-factor 2 \
   --config retention.ms=86400000 \
-  --config segment.ms=1800000
-
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic market.trades.executed \
-  --partitions 12 \
-  --replication-factor $REPLICATION_FACTOR \
+  --config segment.ms=3600000 \
   --config compression.type=lz4 \
-  --config retention.ms=604800000
+  --config max.message.bytes=1000000
 
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic market.ohlcv.aggregated \
-  --partitions 8 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
-  --config retention.ms=2592000000
-
-# Trading Order Topics (Order-based partitioning for processing guarantees)
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic trading.orders.submitted \
-  --partitions 12 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
-  --config retention.ms=2592000000 \
-  --config min.insync.replicas=2
-
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic trading.orders.executed \
-  --partitions 12 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
-  --config retention.ms=2592000000 \
-  --config min.insync.replicas=2
-
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic trading.orders.cancelled \
-  --partitions 8 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
-  --config retention.ms=2592000000
-
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic trading.orders.rejected \
-  --partitions 4 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
-  --config retention.ms=2592000000
-
-# Strategy & Risk Topics (Strategy-based partitioning)
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic strategy.signals.generated \
-  --partitions 16 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
-  --config retention.ms=604800000
-
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic strategy.performance.metrics \
-  --partitions 8 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
-  --config retention.ms=2592000000
-
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic risk.violations.detected \
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic market-data.krx.candles \
   --partitions 6 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
-  --config retention.ms=2592000000 \
-  --config min.insync.replicas=2
-
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic risk.limits.breached \
-  --partitions 4 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
-  --config retention.ms=2592000000 \
-  --config min.insync.replicas=2
-
-# Portfolio & Position Topics
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic portfolio.positions.updated \
-  --partitions 8 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
-  --config retention.ms=2592000000
-
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic portfolio.pnl.calculated \
-  --partitions 6 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
-  --config retention.ms=2592000000
-
-# System & Notification Topics
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic system.health.status \
-  --partitions 2 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
-  --config retention.ms=86400000
-
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic system.alerts.critical \
-  --partitions 4 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
+  --replication-factor 2 \
   --config retention.ms=604800000 \
+  --config segment.ms=86400000 \
+  --config compression.type=lz4
+
+# Cryptocurrency market data
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic market-data.crypto.ticks \
+  --partitions 12 \
+  --replication-factor 2 \
+  --config retention.ms=86400000 \
+  --config segment.ms=3600000 \
+  --config compression.type=lz4
+
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic market-data.crypto.candles \
+  --partitions 6 \
+  --replication-factor 2 \
+  --config retention.ms=604800000 \
+  --config segment.ms=86400000 \
+  --config compression.type=lz4
+
+# Trading signal and order topics
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic signals.entry.buy \
+  --partitions 3 \
+  --replication-factor 2 \
+  --config retention.ms=2592000000 \
+  --config compression.type=snappy
+
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic signals.entry.sell \
+  --partitions 3 \
+  --replication-factor 2 \
+  --config retention.ms=2592000000 \
+  --config compression.type=snappy
+
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic orders.pending \
+  --partitions 3 \
+  --replication-factor 2 \
+  --config retention.ms=86400000 \
+  --config compression.type=snappy
+
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic orders.executions \
+  --partitions 3 \
+  --replication-factor 2 \
+  --config retention.ms=2592000000 \
+  --config compression.type=snappy \
   --config min.insync.replicas=2
 
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic notifications.user.events \
-  --partitions 6 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config compression.type=lz4 \
-  --config retention.ms=604800000
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic orders.failures \
+  --partitions 3 \
+  --replication-factor 2 \
+  --config retention.ms=604800000 \
+  --config compression.type=snappy
 
-# Dead Letter Queue Topics
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic dlq.market.data.failed \
-  --partitions 2 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config retention.ms=2592000000
+# Portfolio and risk topics
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic portfolio.updates \
+  --partitions 3 \
+  --replication-factor 2 \
+  --config retention.ms=2592000000 \
+  --config compression.type=snappy
 
-kafka-topics --bootstrap-server $KAFKA_BROKERS --create \
-  --topic dlq.orders.failed \
-  --partitions 2 \
-  --replication-factor $REPLICATION_FACTOR \
-  --config retention.ms=2592000000
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic risk.alerts \
+  --partitions 3 \
+  --replication-factor 2 \
+  --config retention.ms=604800000 \
+  --config compression.type=snappy
+
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic risk.metrics \
+  --partitions 3 \
+  --replication-factor 2 \
+  --config retention.ms=86400000 \
+  --config compression.type=snappy
+
+# System monitoring topics
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic system.health \
+  --partitions 3 \
+  --replication-factor 2 \
+  --config retention.ms=259200000 \
+  --config compression.type=snappy
+
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic system.errors \
+  --partitions 3 \
+  --replication-factor 2 \
+  --config retention.ms=604800000 \
+  --config compression.type=snappy
+
+# Backtesting topics
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic backtest.requests \
+  --partitions 3 \
+  --replication-factor 2 \
+  --config retention.ms=86400000 \
+  --config compression.type=snappy
+
+docker exec jts-kafka1 kafka-topics --create \
+  --bootstrap-server kafka1:29092 \
+  --topic backtest.results \
+  --partitions 3 \
+  --replication-factor 2 \
+  --config retention.ms=2592000000 \
+  --config compression.type=snappy
 
 echo "All topics created successfully!"
 
@@ -1419,33 +1419,104 @@ export class StreamProcessorService {
 }
 ```
 
+### Storage Migration Strategy
+
+#### Initial Setup (Without 4TB SSD)
+```bash
+# Create data directories
+cd infrastructure/kafka
+mkdir -p data/zookeeper/data data/zookeeper/logs
+mkdir -p data/kafka/kafka1 data/kafka/kafka2 data/kafka/kafka3
+
+# Start Kafka cluster
+docker-compose -f docker-compose.kafka.yml up -d
+
+# Verify cluster health
+docker-compose -f docker-compose.kafka.yml ps
+docker exec jts-kafka1 kafka-broker-api-versions --bootstrap-server kafka1:29092
+```
+
+#### After Installing 4TB SSD
+```bash
+# Stop Kafka cluster
+docker-compose -f docker-compose.kafka.yml down
+
+# Mount the SSD (Samsung 990 PRO or similar)
+sudo fdisk -l
+sudo parted /dev/nvme1n1 mklabel gpt
+sudo parted /dev/nvme1n1 mkpart primary ext4 0% 100%
+sudo mkfs.xfs /dev/nvme1n1p1
+
+# Create mount point and configure
+sudo mkdir -p /mnt/ssd4tb
+echo "UUID=$(sudo blkid -s UUID -o value /dev/nvme1n1p1) /mnt/ssd4tb xfs defaults,noatime,nobarrier,logbufs=8 0 2" | sudo tee -a /etc/fstab
+sudo mount -a
+
+# Set permissions and create directories
+sudo chown -R $USER:$USER /mnt/ssd4tb
+mkdir -p /mnt/ssd4tb/kafka/{kafka1,kafka2,kafka3}
+mkdir -p /mnt/ssd4tb/zookeeper/{data,logs}
+
+# Move existing data
+cp -r data/kafka/* /mnt/ssd4tb/kafka/
+cp -r data/zookeeper/* /mnt/ssd4tb/zookeeper/
+
+# Update docker-compose.kafka.yml volumes to use /mnt/ssd4tb paths
+# Restart cluster
+docker-compose -f docker-compose.kafka.yml up -d
+```
+
+### System Performance Optimization
+
+#### Linux Kernel Tuning
+```bash
+# Add to /etc/sysctl.conf for optimal Kafka performance
+cat << 'EOF' | sudo tee -a /etc/sysctl.conf
+# Network optimizations for Kafka
+net.core.rmem_default=31457280
+net.core.rmem_max=33554432
+net.core.wmem_default=31457280
+net.core.wmem_max=33554432
+net.core.netdev_max_backlog=5000
+net.ipv4.tcp_rmem=4096 87380 33554432
+net.ipv4.tcp_wmem=4096 65536 33554432
+net.ipv4.tcp_max_syn_backlog=8096
+net.ipv4.tcp_slow_start_after_idle=0
+net.ipv4.tcp_tw_reuse=1
+net.ipv4.ip_local_port_range=10240 65535
+
+# File system optimizations
+vm.swappiness=1
+vm.dirty_background_ratio=5
+vm.dirty_ratio=15
+EOF
+
+# Apply settings
+sudo sysctl -p
+```
+
 ### Implementation Steps
 
 #### Phase 1: Infrastructure Setup (Days 1-3)
-1. **LVM Volume Configuration**
+1. **Initial Deployment**
    ```bash
-   # Create dedicated 600GB volume for Kafka
-   lvcreate -L 600G -n lv_kafka vg_jts
-   mkfs.xfs -f /dev/vg_jts/lv_kafka
-   mount -o noatime,nobarrier,logbufs=8 /dev/vg_jts/lv_kafka /var/lib/kafka
-   ```
-
-2. **Docker Compose Deployment**
-   ```bash
-   # Deploy Kafka cluster
+   # Deploy Kafka cluster with local storage
+   cd infrastructure/kafka
    docker-compose -f docker-compose.kafka.yml up -d
    
    # Verify cluster health
-   docker logs jts-kafka-1
-   docker logs jts-kafka-2
-   docker logs jts-kafka-3
+   docker logs jts-kafka1
+   docker logs jts-kafka2
+   docker logs jts-kafka3
    ```
 
-3. **Topic Creation and Configuration**
+2. **Topic Creation and Configuration**
    ```bash
    # Create all topics with proper partitioning
-   chmod +x scripts/kafka-setup/create-topics.sh
-   ./scripts/kafka-setup/create-topics.sh
+   chmod +x setup-topics.sh
+   ./setup-topics.sh
+   
+   # Access Kafka UI at http://localhost:8080
    ```
 
 #### Phase 2: Schema and Serialization (Days 4-5)
@@ -1494,28 +1565,81 @@ export class StreamProcessorService {
 #### Phase 4: Monitoring and Testing (Days 9-10)
 1. **Monitoring Setup**
    ```yaml
-   # Add Kafka monitoring to docker-compose
+   # Add Prometheus Kafka exporter to docker-compose
    kafka-exporter:
      image: danielqsj/kafka-exporter:latest
+     container_name: jts-kafka-exporter
      ports:
        - "9308:9308"
      command:
-       - '--kafka.server=kafka-broker-1:29092'
-       - '--kafka.server=kafka-broker-2:29093'
-       - '--kafka.server=kafka-broker-3:29094'
+       - '--kafka.server=kafka1:29092'
+       - '--kafka.server=kafka2:29093'
+       - '--kafka.server=kafka3:29094'
+     networks:
+       - jts-network
    ```
 
 2. **Performance Testing**
    ```bash
    # Test producer performance
-   kafka-producer-perf-test --topic market.price.ticks \
+   docker exec jts-kafka1 kafka-producer-perf-test \
+     --topic market-data.krx.ticks \
      --num-records 100000 --record-size 1000 \
-     --throughput 10000 --producer-props bootstrap.servers=localhost:9092
+     --throughput 10000 --producer-props bootstrap.servers=kafka1:29092
    
    # Test consumer performance
-   kafka-consumer-perf-test --topic market.price.ticks \
-     --bootstrap-server localhost:9092 --messages 100000
+   docker exec jts-kafka1 kafka-consumer-perf-test \
+     --topic market-data.krx.ticks \
+     --bootstrap-server kafka1:29092 --messages 100000
    ```
+
+### Backup and Recovery Strategy
+
+#### Daily Backup Script
+```bash
+#!/bin/bash
+# infrastructure/kafka/backup-topics.sh
+
+BACKUP_DIR="/mnt/nas/kafka-backups/$(date +%Y%m%d)"
+mkdir -p $BACKUP_DIR
+
+# Export critical topics
+for topic in orders.executions portfolio.updates risk.alerts; do
+  docker exec jts-kafka1 kafka-console-consumer \
+    --bootstrap-server kafka1:29092 \
+    --topic $topic \
+    --from-beginning \
+    --property print.timestamp=true \
+    --timeout-ms 10000 > $BACKUP_DIR/$topic.json
+done
+
+# Sync to NAS for redundancy
+rsync -av /mnt/ssd4tb/kafka/ /mnt/nas/kafka-mirror/
+```
+
+### Troubleshooting Guide
+
+#### Common Issues
+```bash
+# Check broker availability
+docker logs jts-kafka1
+docker-compose -f docker-compose.kafka.yml restart kafka1
+
+# Check consumer lag
+docker exec jts-kafka1 kafka-consumer-groups \
+  --bootstrap-server kafka1:29092 --list
+
+docker exec jts-kafka1 kafka-consumer-groups \
+  --bootstrap-server kafka1:29092 \
+  --describe --group <group-name>
+
+# Force log cleanup for disk space
+docker exec jts-kafka1 kafka-configs \
+  --bootstrap-server kafka1:29092 \
+  --alter --entity-type topics \
+  --entity-name <topic-name> \
+  --add-config retention.ms=3600000
+```
 
 ## Dependencies
 
@@ -1551,29 +1675,37 @@ export class StreamProcessorService {
 
 ```
 When implementing this feature:
-1. Create infrastructure/kafka/ directory with Docker Compose configuration for 3-broker cluster
-2. Set up XFS filesystem on dedicated 600GB LVM volume with optimized mount options
-3. Implement comprehensive topic structure with strategic partitioning for different data types
-4. Create Protocol Buffers schema definitions with proper versioning and TypeScript generation
-5. Implement high-performance producer service with batching, compression, and retry logic
-6. Create robust consumer service with batch processing, error handling, and DLQ support
-7. Set up stream processing topology for real-time data transformation and aggregation
-8. Configure comprehensive monitoring with JMX metrics and health checks
-9. Create performance testing scripts to validate throughput and latency requirements
-10. Document all topic schemas, partitioning strategies, and operational procedures
-11. Test end-to-end message flow with proper error handling and recovery scenarios
-12. Implement proper security configuration with SASL/SSL for production deployment
+1. Use existing infrastructure/kafka/ directory with Docker Compose configuration for 3-broker cluster
+2. Initially deploy with local storage under ./data/, prepare migration path to /mnt/ssd4tb when SSD is available
+3. Deploy Confluent Schema Registry alongside Kafka for schema management
+4. Use existing topic naming convention (market-data.krx.*, orders.*, signals.*, etc.) from setup-topics.sh
+5. Apply Linux kernel tuning parameters from kafka-startup-guide.md for optimal performance
+6. Create Protocol Buffers schema definitions with Schema Registry integration
+7. Implement high-performance producer service with batching, LZ4 compression, and retry logic
+8. Create robust consumer service with batch processing, error handling, and proper offset management
+9. Set up stream processing topology for real-time data transformation and aggregation
+10. Deploy Kafka UI for visual monitoring and management at port 8080
+11. Implement backup strategy with daily exports to NAS for critical topics
+12. Create troubleshooting scripts for common operational issues
+13. Use Prometheus Kafka exporter for metrics collection
+14. Test with kafka-producer-perf-test and kafka-consumer-perf-test tools
+15. For production, implement SASL/SSL authentication and increase heap to 8GB per broker
 ```
 
 ## Notes
 
-- Kafka cluster configuration is optimized for high-frequency trading workloads
-- Protocol Buffers provide efficient serialization with schema evolution capabilities
-- Consumer group management ensures scalable and fault-tolerant message processing
-- Stream processing topology enables real-time analytics and complex event processing
-- Comprehensive monitoring is essential for production reliability and performance tuning
-- Consider implementing Kafka Streams for complex event processing in future iterations
+- Existing Kafka infrastructure in place with working Docker Compose configuration
+- Dual storage strategy: initial local deployment, production on 4TB NVMe SSD
+- Topic naming follows existing convention: market-data.krx.*, orders.*, signals.*
+- Confluent Schema Registry provides centralized schema management
+- Kafka UI at port 8080 provides visual cluster monitoring
+- Replication factor of 2 balances durability with resource usage
+- Korean market (KRX) and cryptocurrency market topics included
+- Comprehensive Linux kernel tuning parameters documented
+- Backup and recovery procedures established for critical topics
+- Prometheus integration ready for production monitoring
 
 ## Status Updates
 
 - **2025-08-24**: Feature specification created with comprehensive Kafka setup architecture
+- **2025-08-28**: Updated spec with existing infrastructure configuration from brainstorming files


### PR DESCRIPTION
## Summary
  - Updated message queue specification with existing infrastructure configuration
  details
  - Aligned spec with working Docker Compose setup and topic naming conventions
  - Added comprehensive deployment and migration strategy documentation

  ## Technical Details
  - Updated `1006.spec.md` to reflect existing 3-broker Kafka cluster configuration
  - Changed broker names from `kafka-broker-1/2/3` to `kafka1/2/3` to match
  implementation
  - Added `schema-registry` service configuration for Confluent Schema Registry
  - Updated topic creation script to use existing naming convention
  (`market-data.krx.*`, `orders.*`, `signals.*`)
  - Integrated Korean market (KRX) and cryptocurrency-specific topics
  - Added storage migration strategy from local storage to 4TB NVMe SSD
  (`/mnt/ssd4tb`)
  - Included Linux kernel tuning parameters for optimal Kafka performance
  - Added backup strategy with daily exports and troubleshooting procedures
  - Updated monitoring configuration with `kafka-ui` and Prometheus exporter
  - Modified replication factor from 3 to 2 for practical 3-broker deployment
  - Added comprehensive deployment phases and operational procedures

  ## Infrastructure Changes
  - Schema Registry integration with backward compatibility support
  - Kafka UI for visual cluster monitoring at port 8080
  - Dual storage strategy: initial local deployment with SSD migration path
  - Performance optimization with JVM heap settings (6GB initial, 8GB production)
  - Network and I/O threading configuration (8 threads each per broker)

  ## Testing
  - Verify spec aligns with existing `infrastructure/kafka/` directory structure
  - Confirm topic naming matches `setup-topics.sh` script conventions
  - Review storage migration procedures for 4TB SSD deployment

  ## Breaking Changes
  - None - this is documentation update only