### PR TITLE
fix(workflow): resolve yarn registry connection issue

### DIFF
--- a/.github/workflows/generate-index-and-notify.yml
+++ b/.github/workflows/generate-index-and-notify.yml
@@ -25,6 +25,12 @@ jobs:
           node-version: '20'
           cache: 'yarn'
           
+      - name: Configure yarn for public registry
+        run: |
+          yarn config set registry https://registry.npmjs.org/
+          yarn config delete httpProxy
+          yarn config delete httpsProxy
+          
       - name: Install dependencies
         run: yarn install --frozen-lockfile
         

--- a/specs/E01/spec.md
+++ b/specs/E01/spec.md
@@ -520,4 +520,4 @@ Feature F01 (Storage Infrastructure) has been decomposed into specialized tasks 
 
 ## Status Updates
 
-- **2025-08-24**: Epic created and documented
+- **2025-08-24**: Epic created and documented# Test Update


### PR DESCRIPTION
Fixed GitHub Actions workflow failure by configuring yarn to use public npm registry instead of local registry that was causing ECONNREFUSED errors.