### PR TITLE
Correct hierarchical link generation in `index.template.md`

### DIFF
--- a/specs-data.json
+++ b/specs-data.json
@@ -13,19 +13,6 @@
       "estimated_hours": 120,
       "actual_hours": 0
     },
-    "E11": {
-      "id": "E11",
-      "title": "Performance Optimization & Scaling",
-      "type": "epic",
-      "parent": "",
-      "status": "draft",
-      "priority": "high",
-      "created": "2025-08-24",
-      "updated": "2025-08-24",
-      "children": [],
-      "estimated_hours": 120,
-      "actual_hours": 0
-    },
     "E10": {
       "id": "E10",
       "title": "Cryptocurrency Integration",
@@ -42,6 +29,19 @@
     "E09": {
       "id": "E09",
       "title": "Backtesting Framework",
+      "type": "epic",
+      "parent": "",
+      "status": "draft",
+      "priority": "high",
+      "created": "2025-08-24",
+      "updated": "2025-08-24",
+      "children": [],
+      "estimated_hours": 120,
+      "actual_hours": 0
+    },
+    "E11": {
+      "id": "E11",
+      "title": "Performance Optimization & Scaling",
       "type": "epic",
       "parent": "",
       "status": "draft",
@@ -201,19 +201,6 @@
       "estimated_hours": 30,
       "actual_hours": 0
     },
-    "F09": {
-      "id": "F09",
-      "title": "Security Foundation",
-      "type": "feature",
-      "parent": "E01",
-      "status": "draft",
-      "priority": "high",
-      "created": "2025-08-24",
-      "updated": "2025-08-24",
-      "children": [],
-      "estimated_hours": 16,
-      "actual_hours": 0
-    },
     "F10": {
       "id": "F10",
       "title": "Testing Framework Setup",
@@ -225,6 +212,19 @@
       "updated": "2025-08-24",
       "children": [],
       "estimated_hours": 14,
+      "actual_hours": 0
+    },
+    "F09": {
+      "id": "F09",
+      "title": "Security Foundation",
+      "type": "feature",
+      "parent": "E01",
+      "status": "draft",
+      "priority": "high",
+      "created": "2025-08-24",
+      "updated": "2025-08-24",
+      "children": [],
+      "estimated_hours": 16,
       "actual_hours": 0
     },
     "F08": {
@@ -240,19 +240,6 @@
       "estimated_hours": 18,
       "actual_hours": 0
     },
-    "F06": {
-      "id": "F06",
-      "title": "Message Queue Setup",
-      "type": "feature",
-      "parent": "E01",
-      "status": "draft",
-      "priority": "high",
-      "created": "2025-08-24",
-      "updated": "2025-08-24",
-      "children": [],
-      "estimated_hours": 16,
-      "actual_hours": 0
-    },
     "F07": {
       "id": "F07",
       "title": "Service Communication Patterns",
@@ -264,6 +251,19 @@
       "updated": "2025-08-24",
       "children": [],
       "estimated_hours": 14,
+      "actual_hours": 0
+    },
+    "F06": {
+      "id": "F06",
+      "title": "Message Queue Setup",
+      "type": "feature",
+      "parent": "E01",
+      "status": "draft",
+      "priority": "high",
+      "created": "2025-08-24",
+      "updated": "2025-08-24",
+      "children": [],
+      "estimated_hours": 16,
       "actual_hours": 0
     },
     "F05": {
@@ -380,6 +380,112 @@
         "e5381ea"
       ]
     },
+    "T06": {
+      "id": "T06",
+      "title": "Tiered Storage Management",
+      "type": "task",
+      "parent": "F01",
+      "status": "completed",
+      "priority": "medium",
+      "created": "2025-08-24",
+      "updated": "2025-08-30",
+      "children": [],
+      "estimated_hours": 4,
+      "actual_hours": 2,
+      "pull_requests": [],
+      "commits": [
+        "65d4b03",
+        "f5c5cea",
+        "eae37cd",
+        "80c1364",
+        "e1fd699",
+        "675785b",
+        2838591,
+        "e7ccf93"
+      ]
+    },
+    "T05": {
+      "id": "T05",
+      "title": "Storage Performance Optimization",
+      "type": "task",
+      "parent": "F01",
+      "status": "completed",
+      "priority": "medium",
+      "created": "2025-08-24",
+      "updated": "2025-08-30",
+      "children": [],
+      "estimated_hours": 2,
+      "actual_hours": 2.5,
+      "pull_requests": [],
+      "commits": []
+    },
+    "T04": {
+      "id": "T04",
+      "title": "Cold Storage (NAS) Integration",
+      "type": "task",
+      "parent": "F01",
+      "status": "completed",
+      "priority": "medium",
+      "created": "2025-08-24",
+      "updated": "2025-08-26",
+      "children": [],
+      "estimated_hours": 3,
+      "actual_hours": 1,
+      "pull_requests": [
+        "#15"
+      ],
+      "commits": [
+        "d41de7a"
+      ]
+    },
+    "T03": {
+      "id": "T03",
+      "title": "Warm Storage (SATA) Setup",
+      "type": "task",
+      "parent": "F01",
+      "status": "draft",
+      "priority": "medium",
+      "created": "2025-08-24",
+      "updated": "2025-08-24",
+      "children": [],
+      "estimated_hours": 3,
+      "actual_hours": 0,
+      "pull_requests": [],
+      "commits": []
+    },
+    "T02": {
+      "id": "T02",
+      "title": "Database Mount Integration",
+      "type": "task",
+      "parent": "F01",
+      "status": "completed",
+      "priority": "high",
+      "created": "2025-08-24",
+      "updated": "2025-08-27",
+      "children": [],
+      "estimated_hours": 4,
+      "actual_hours": 2.5,
+      "pull_requests": [],
+      "commits": []
+    },
+    "T01": {
+      "id": "T01",
+      "title": "Hot Storage (NVMe) Directory Setup",
+      "type": "task",
+      "parent": "F01",
+      "status": "completed",
+      "priority": "high",
+      "created": "2025-08-24",
+      "updated": "2025-08-24",
+      "children": [],
+      "estimated_hours": 2,
+      "actual_hours": 3,
+      "pull_requests": [],
+      "commits": [
+        "2da9f8d",
+        "08e4cc5"
+      ]
+    },
     "T11": {
       "id": "T11",
       "title": "CI/CD Monitoring and Notifications",
@@ -454,112 +560,6 @@
       "actual_hours": 0,
       "pull_requests": [],
       "commits": []
-    },
-    "T06": {
-      "id": "T06",
-      "title": "Tiered Storage Management",
-      "type": "task",
-      "parent": "F01",
-      "status": "completed",
-      "priority": "medium",
-      "created": "2025-08-24",
-      "updated": "2025-08-30",
-      "children": [],
-      "estimated_hours": 4,
-      "actual_hours": 2,
-      "pull_requests": [],
-      "commits": [
-        "65d4b03",
-        "f5c5cea",
-        "eae37cd",
-        "80c1364",
-        "e1fd699",
-        "675785b",
-        2838591,
-        "e7ccf93"
-      ]
-    },
-    "T05": {
-      "id": "T05",
-      "title": "Storage Performance Optimization",
-      "type": "task",
-      "parent": "F01",
-      "status": "completed",
-      "priority": "medium",
-      "created": "2025-08-24",
-      "updated": "2025-08-30",
-      "children": [],
-      "estimated_hours": 2,
-      "actual_hours": 2.5,
-      "pull_requests": [],
-      "commits": []
-    },
-    "T04": {
-      "id": "T04",
-      "title": "Cold Storage (NAS) Integration",
-      "type": "task",
-      "parent": "F01",
-      "status": "done",
-      "priority": "medium",
-      "created": "2025-08-24",
-      "updated": "2025-08-26",
-      "children": [],
-      "estimated_hours": 3,
-      "actual_hours": 1,
-      "pull_requests": [
-        "#15"
-      ],
-      "commits": [
-        "d41de7a"
-      ]
-    },
-    "T03": {
-      "id": "T03",
-      "title": "Warm Storage (SATA) Setup",
-      "type": "task",
-      "parent": "F01",
-      "status": "draft",
-      "priority": "medium",
-      "created": "2025-08-24",
-      "updated": "2025-08-24",
-      "children": [],
-      "estimated_hours": 3,
-      "actual_hours": 0,
-      "pull_requests": [],
-      "commits": []
-    },
-    "T02": {
-      "id": "T02",
-      "title": "Database Mount Integration",
-      "type": "task",
-      "parent": "F01",
-      "status": "done",
-      "priority": "high",
-      "created": "2025-08-24",
-      "updated": "2025-08-27",
-      "children": [],
-      "estimated_hours": 4,
-      "actual_hours": 2.5,
-      "pull_requests": [],
-      "commits": []
-    },
-    "T01": {
-      "id": "T01",
-      "title": "Hot Storage (NVMe) Directory Setup",
-      "type": "task",
-      "parent": "F01",
-      "status": "done",
-      "priority": "high",
-      "created": "2025-08-24",
-      "updated": "2025-08-24",
-      "children": [],
-      "estimated_hours": 2,
-      "actual_hours": 3,
-      "pull_requests": [],
-      "commits": [
-        "2da9f8d",
-        "08e4cc5"
-      ]
     }
   },
   "stats": {
@@ -569,14 +569,17 @@
     "total_subtasks": 0,
     "completed": [
       "T06",
-      "T05"
+      "T05",
+      "T04",
+      "T02",
+      "T01"
     ],
     "in_progress": [],
     "draft": [
       "E12",
-      "E11",
       "E10",
       "E09",
+      "E11",
       "E08",
       "E07",
       "E06",
@@ -586,22 +589,22 @@
       "E02",
       "E01",
       "F11",
-      "F09",
       "F10",
+      "F09",
       "F08",
-      "F06",
       "F07",
+      "F06",
       "F05",
       "F04",
       "F03",
       "F02",
       "F01",
+      "T03",
       "T11",
       "T10",
       "T09",
       "T08",
-      "T07",
-      "T03"
+      "T07"
     ],
     "blocked": []
   },
@@ -609,19 +612,6 @@
     "E12": {
       "id": "E12",
       "title": "Deployment & DevOps",
-      "type": "epic",
-      "parent": "",
-      "status": "draft",
-      "priority": "high",
-      "created": "2025-08-24",
-      "updated": "2025-08-24",
-      "children": {},
-      "estimated_hours": 120,
-      "actual_hours": 0
-    },
-    "E11": {
-      "id": "E11",
-      "title": "Performance Optimization & Scaling",
       "type": "epic",
       "parent": "",
       "status": "draft",
@@ -648,6 +638,19 @@
     "E09": {
       "id": "E09",
       "title": "Backtesting Framework",
+      "type": "epic",
+      "parent": "",
+      "status": "draft",
+      "priority": "high",
+      "created": "2025-08-24",
+      "updated": "2025-08-24",
+      "children": {},
+      "estimated_hours": 120,
+      "actual_hours": 0
+    },
+    "E11": {
+      "id": "E11",
+      "title": "Performance Optimization & Scaling",
       "type": "epic",
       "parent": "",
       "status": "draft",
@@ -759,19 +762,6 @@
           "estimated_hours": 30,
           "actual_hours": 0
         },
-        "F09": {
-          "id": "F09",
-          "title": "Comprehensive Error Handling and Recovery System",
-          "type": "feature",
-          "parent": "E02",
-          "status": "draft",
-          "priority": "high",
-          "created": "2025-08-25",
-          "updated": "2025-08-25",
-          "children": {},
-          "estimated_hours": 30,
-          "actual_hours": 0
-        },
         "F10": {
           "id": "F10",
           "title": "Broker Testing Framework and Mock Services",
@@ -783,6 +773,19 @@
           "updated": "2025-08-25",
           "children": {},
           "estimated_hours": 25,
+          "actual_hours": 0
+        },
+        "F09": {
+          "id": "F09",
+          "title": "Comprehensive Error Handling and Recovery System",
+          "type": "feature",
+          "parent": "E02",
+          "status": "draft",
+          "priority": "high",
+          "created": "2025-08-25",
+          "updated": "2025-08-25",
+          "children": {},
+          "estimated_hours": 30,
           "actual_hours": 0
         },
         "F08": {
@@ -798,9 +801,9 @@
           "estimated_hours": 25,
           "actual_hours": 0
         },
-        "F06": {
-          "id": "F06",
-          "title": "Multi-Account Pool Management System",
+        "F07": {
+          "id": "F07",
+          "title": "Smart Order Routing and Execution Engine",
           "type": "feature",
           "parent": "E02",
           "status": "draft",
@@ -811,9 +814,9 @@
           "estimated_hours": 35,
           "actual_hours": 0
         },
-        "F07": {
-          "id": "F07",
-          "title": "Smart Order Routing and Execution Engine",
+        "F06": {
+          "id": "F06",
+          "title": "Multi-Account Pool Management System",
           "type": "feature",
           "parent": "E02",
           "status": "draft",
@@ -979,6 +982,112 @@
           "updated": "2025-08-24",
           "children": {},
           "estimated_hours": 20,
+          "actual_hours": 0,
+          "pull_requests": [],
+          "commits": []
+        },
+        "F03": {
+          "id": "F03",
+          "title": "Monorepo Structure and Tooling",
+          "type": "feature",
+          "parent": "E01",
+          "status": "draft",
+          "priority": "high",
+          "created": "2025-08-24",
+          "updated": "2025-08-28",
+          "children": {
+            "T06": {
+              "id": "T06",
+              "title": "Configure CI/CD Pipeline and Automation",
+              "type": "task",
+              "parent": "F03",
+              "status": "draft",
+              "priority": "medium",
+              "created": "2025-08-28",
+              "updated": "2025-08-28",
+              "children": {},
+              "estimated_hours": 2,
+              "actual_hours": 0,
+              "pull_requests": [],
+              "commits": []
+            },
+            "T05": {
+              "id": "T05",
+              "title": "Create Development Tooling and Generators",
+              "type": "task",
+              "parent": "F03",
+              "status": "draft",
+              "priority": "medium",
+              "created": "2025-08-28",
+              "updated": "2025-08-28",
+              "children": {},
+              "estimated_hours": 2.5,
+              "actual_hours": 0,
+              "pull_requests": [],
+              "commits": []
+            },
+            "T04": {
+              "id": "T04",
+              "title": "Implement TypeScript Configuration and Linting",
+              "type": "task",
+              "parent": "F03",
+              "status": "draft",
+              "priority": "high",
+              "created": "2025-08-28",
+              "updated": "2025-08-28",
+              "children": {},
+              "estimated_hours": 2,
+              "actual_hours": 0,
+              "pull_requests": [],
+              "commits": []
+            },
+            "T03": {
+              "id": "T03",
+              "title": "Set Up Build and Testing Infrastructure",
+              "type": "task",
+              "parent": "F03",
+              "status": "draft",
+              "priority": "high",
+              "created": "2025-08-28",
+              "updated": "2025-08-28",
+              "children": {},
+              "estimated_hours": 2.5,
+              "actual_hours": 0,
+              "pull_requests": [],
+              "commits": []
+            },
+            "T02": {
+              "id": "T02",
+              "title": "Configure Shared Libraries Infrastructure",
+              "type": "task",
+              "parent": "F03",
+              "status": "draft",
+              "priority": "high",
+              "created": "2025-08-28",
+              "updated": "2025-08-28",
+              "children": {},
+              "estimated_hours": 3,
+              "actual_hours": 0,
+              "pull_requests": [],
+              "commits": []
+            },
+            "T01": {
+              "id": "T01",
+              "title": "Initialize Nx Workspace with Base Configuration",
+              "type": "task",
+              "parent": "F03",
+              "status": "draft",
+              "priority": "high",
+              "created": "2025-08-28",
+              "updated": "2025-08-28",
+              "children": {},
+              "estimated_hours": 2,
+              "actual_hours": 0,
+              "pull_requests": [],
+              "commits": []
+            }
+          },
+          "estimated_hours": 12,
           "actual_hours": 0,
           "pull_requests": [],
           "commits": []
@@ -1164,112 +1273,6 @@
           "pull_requests": [],
           "commits": []
         },
-        "F03": {
-          "id": "F03",
-          "title": "Monorepo Structure and Tooling",
-          "type": "feature",
-          "parent": "E01",
-          "status": "draft",
-          "priority": "high",
-          "created": "2025-08-24",
-          "updated": "2025-08-28",
-          "children": {
-            "T06": {
-              "id": "T06",
-              "title": "Configure CI/CD Pipeline and Automation",
-              "type": "task",
-              "parent": "F03",
-              "status": "draft",
-              "priority": "medium",
-              "created": "2025-08-28",
-              "updated": "2025-08-28",
-              "children": {},
-              "estimated_hours": 2,
-              "actual_hours": 0,
-              "pull_requests": [],
-              "commits": []
-            },
-            "T05": {
-              "id": "T05",
-              "title": "Create Development Tooling and Generators",
-              "type": "task",
-              "parent": "F03",
-              "status": "draft",
-              "priority": "medium",
-              "created": "2025-08-28",
-              "updated": "2025-08-28",
-              "children": {},
-              "estimated_hours": 2.5,
-              "actual_hours": 0,
-              "pull_requests": [],
-              "commits": []
-            },
-            "T04": {
-              "id": "T04",
-              "title": "Implement TypeScript Configuration and Linting",
-              "type": "task",
-              "parent": "F03",
-              "status": "draft",
-              "priority": "high",
-              "created": "2025-08-28",
-              "updated": "2025-08-28",
-              "children": {},
-              "estimated_hours": 2,
-              "actual_hours": 0,
-              "pull_requests": [],
-              "commits": []
-            },
-            "T03": {
-              "id": "T03",
-              "title": "Set Up Build and Testing Infrastructure",
-              "type": "task",
-              "parent": "F03",
-              "status": "draft",
-              "priority": "high",
-              "created": "2025-08-28",
-              "updated": "2025-08-28",
-              "children": {},
-              "estimated_hours": 2.5,
-              "actual_hours": 0,
-              "pull_requests": [],
-              "commits": []
-            },
-            "T02": {
-              "id": "T02",
-              "title": "Configure Shared Libraries Infrastructure",
-              "type": "task",
-              "parent": "F03",
-              "status": "draft",
-              "priority": "high",
-              "created": "2025-08-28",
-              "updated": "2025-08-28",
-              "children": {},
-              "estimated_hours": 3,
-              "actual_hours": 0,
-              "pull_requests": [],
-              "commits": []
-            },
-            "T01": {
-              "id": "T01",
-              "title": "Initialize Nx Workspace with Base Configuration",
-              "type": "task",
-              "parent": "F03",
-              "status": "draft",
-              "priority": "high",
-              "created": "2025-08-28",
-              "updated": "2025-08-28",
-              "children": {},
-              "estimated_hours": 2,
-              "actual_hours": 0,
-              "pull_requests": [],
-              "commits": []
-            }
-          },
-          "estimated_hours": 12,
-          "actual_hours": 0,
-          "pull_requests": [],
-          "commits": []
-        },
         "F02": {
           "id": "F02",
           "title": "Development Environment Setup",
@@ -1430,7 +1433,7 @@
               "title": "Cold Storage (NAS) Integration",
               "type": "task",
               "parent": "F01",
-              "status": "done",
+              "status": "completed",
               "priority": "medium",
               "created": "2025-08-24",
               "updated": "2025-08-26",
@@ -1464,7 +1467,7 @@
               "title": "Database Mount Integration",
               "type": "task",
               "parent": "F01",
-              "status": "done",
+              "status": "completed",
               "priority": "high",
               "created": "2025-08-24",
               "updated": "2025-08-27",
@@ -1479,7 +1482,7 @@
               "title": "Hot Storage (NVMe) Directory Setup",
               "type": "task",
               "parent": "F01",
-              "status": "done",
+              "status": "completed",
               "priority": "high",
               "created": "2025-08-24",
               "updated": "2025-08-24",

--- a/specs/E01/F01/T01/spec.md
+++ b/specs/E01/F01/T01/spec.md
@@ -15,7 +15,7 @@ epic: E01
 domain: infrastructure
 
 # === WORKFLOW ===
-status: done
+status: completed
 priority: high
 
 # === TRACKING ===

--- a/specs/E01/F01/T02/spec.md
+++ b/specs/E01/F01/T02/spec.md
@@ -15,7 +15,7 @@ epic: E01
 domain: infrastructure
 
 # === WORKFLOW ===
-status: done
+status: completed
 priority: high
 
 # === TRACKING ===

--- a/specs/E01/F01/T04/spec.md
+++ b/specs/E01/F01/T04/spec.md
@@ -15,7 +15,7 @@ epic: E01
 domain: infrastructure
 
 # === WORKFLOW ===
-status: done
+status: completed
 priority: medium
 
 # === TRACKING ===

--- a/templates/index.template.md
+++ b/templates/index.template.md
@@ -28,13 +28,13 @@ Completed: {{stats.completed.length}}/{{calculated.totalSpecs}}
 
 {{#if children}}
 {{#each children}}
-- {{statusIcon status}} [{{@key}} - {{title}}]({{../key}}/{{@key}}/spec.md) `{{status}}`
+- {{statusIcon status}} [{{@key}} - {{title}}]({{parent}}/{{@key}}/spec.md) `{{status}}`
 {{#if children}}
 {{#each children}}
-  - {{statusIcon status}} [{{@key}} - {{title}}]({{../../key}}/{{../key}}/{{@key}}/spec.md) `{{status}}`
+  - {{statusIcon status}} [{{@key}} - {{title}}]({{../parent}}/{{parent}}/{{@key}}/spec.md) `{{status}}`
 {{#if children}}
 {{#each children}}
-    - {{statusIcon status}} [{{@key}} - {{title}}]({{../../../key}}/{{../../key}}/{{../key}}/{{@key}}/spec.md) `{{status}}`
+    - {{statusIcon status}} [{{@key}} - {{title}}]({{../../parent}}/{{../parent}}/{{parent}}/{{@key}}/spec.md) `{{status}}`
 {{/each}}
 {{/if}}
 {{/each}}


### PR DESCRIPTION
## Summary
- Fixed broken hierarchical links in generated spec dashboard
- Corrected Handlebars template to use proper data field references
- Updated progress statistics to reflect current completion status

## Technical Details
- Modified `templates/index.template.md` to replace `{{../key}}` with
`{{parent}}` data fields
- Fixed path generation for nested specs:
`{{../parent}}/{{parent}}/{{@key}}/spec.md`
- Regenerated `specs/index.md` with corrected links and updated progress
(14.7%)
- Template now properly constructs paths like `E01/F01/T01/spec.md` instead
 of malformed `//T01/spec.md`

## Testing
- Run `yarn generate:index` to verify link generation
- Check that all nested spec links resolve to correct file paths
- Verify progress statistics match current completion data

## Root Cause
The template was using undefined Handlebars context variables `{{../key}}`
instead of the actual `parent` field from the JSON data structure, causing
malformed file paths in the generated markdown.
