### PR TITLE
fix(specs): Fix hierarchical path generation and task indentation in spec index

### DIFF
--- a/scripts/utilities/generate-index.ts
+++ b/scripts/utilities/generate-index.ts
@@ -59,6 +59,13 @@ handlebars.registerHelper('statusIcon', (status: string) => {
   return icons[normalizedStatus] || '';
 });
 
+// Helper to build correct spec file paths
+handlebars.registerHelper('specPath', (...args: any[]) => {
+  // Remove the last argument (Handlebars options object)
+  const keys = args.slice(0, -1).filter(k => k);
+  return keys.join('/');
+});
+
 // Process hierarchy to normalize statuses and calculate parent statuses
 function processHierarchy(hierarchy: any): any {
   if (!hierarchy || typeof hierarchy !== 'object') {

--- a/specs/index.md
+++ b/specs/index.md
@@ -22,47 +22,47 @@ Completed: 18/62
 ## 📁 Specifications
 
 
-### 🚧 [E01 - Foundation &amp; Infrastructure Setup](E01/spec.md)
+### 🚧 [E01 - Foundation & Infrastructure Setup](E01/spec.md)
 
 > Status: `in_progress` | Priority: `high`
 
 
 - ✅ [F01 - Storage Infrastructure Coordination](E01/F01/spec.md) `completed`
-  - ✅ [T01 - Hot Storage (NVMe) Directory Setup](E01/E01-F01/T01/spec.md) `completed`
-      - ✅ [T02 - Database Mount Integration](E01/E01-F01/T02/spec.md) `completed`
-      - ✅ [T03 - Warm Storage (SATA) Setup](E01/E01-F01/T03/spec.md) `completed`
-      - ✅ [T04 - Cold Storage (NAS) Integration](E01/E01-F01/T04/spec.md) `completed`
-      - ✅ [T05 - Storage Performance Optimization](E01/E01-F01/T05/spec.md) `completed`
-      - ✅ [T06 - Tiered Storage Management](E01/E01-F01/T06/spec.md) `completed`
+  - ✅ [T01 - Hot Storage (NVMe) Directory Setup](E01/F01/T01/spec.md) `completed`
+      - ✅ [T02 - Database Mount Integration](E01/F01/T02/spec.md) `completed`
+      - ✅ [T03 - Warm Storage (SATA) Setup](E01/F01/T03/spec.md) `completed`
+      - ✅ [T04 - Cold Storage (NAS) Integration](E01/F01/T04/spec.md) `completed`
+      - ✅ [T05 - Storage Performance Optimization](E01/F01/T05/spec.md) `completed`
+      - ✅ [T06 - Tiered Storage Management](E01/F01/T06/spec.md) `completed`
     
 - ✅ [F02 - Development Environment Setup](E01/F02/spec.md) `completed`
-  - ✅ [T01 - Node.js and Yarn Environment Setup](E01/E01-F02/T01/spec.md) `completed`
-      - ✅ [T02 - VS Code IDE Configuration](E01/E01-F02/T02/spec.md) `completed`
-      - ✅ [T03 - Docker and Database Services Setup](E01/E01-F02/T03/spec.md) `completed`
-      - ✅ [T04 - Environment Configuration and Secrets Management](E01/E01-F02/T04/spec.md) `completed`
-      - ✅ [T05 - Code Quality Tools and Git Hooks](E01/E01-F02/T05/spec.md) `completed`
-      - ✅ [T06 - Development Scripts and Automation](E01/E01-F02/T06/spec.md) `completed`
+  - ✅ [T01 - Node.js and Yarn Environment Setup](E01/F02/T01/spec.md) `completed`
+      - ✅ [T02 - VS Code IDE Configuration](E01/F02/T02/spec.md) `completed`
+      - ✅ [T03 - Docker and Database Services Setup](E01/F02/T03/spec.md) `completed`
+      - ✅ [T04 - Environment Configuration and Secrets Management](E01/F02/T04/spec.md) `completed`
+      - ✅ [T05 - Code Quality Tools and Git Hooks](E01/F02/T05/spec.md) `completed`
+      - ✅ [T06 - Development Scripts and Automation](E01/F02/T06/spec.md) `completed`
     
 - 🚧 [F03 - Monorepo Structure and Tooling](E01/F03/spec.md) `in_progress`
-  - ✅ [T01 - Initialize Nx Workspace with Base Configuration](E01/E01-F03/T01/spec.md) `completed`
-      - ✅ [T02 - Configure Shared Libraries Infrastructure](E01/E01-F03/T02/spec.md) `completed`
-      - ✅ [T03 - Set Up Build and Testing Infrastructure](E01/E01-F03/T03/spec.md) `completed`
-      - ✅ [T04 - Implement TypeScript Configuration and Linting](E01/E01-F03/T04/spec.md) `completed`
-      - 📋 [T05 - Create Development Tooling and Generators](E01/E01-F03/T05/spec.md) `draft`
-      - 📋 [T06 - Configure CI/CD Pipeline and Automation](E01/E01-F03/T06/spec.md) `draft`
+  - ✅ [T01 - Initialize Nx Workspace with Base Configuration](E01/F03/T01/spec.md) `completed`
+      - ✅ [T02 - Configure Shared Libraries Infrastructure](E01/F03/T02/spec.md) `completed`
+      - ✅ [T03 - Set Up Build and Testing Infrastructure](E01/F03/T03/spec.md) `completed`
+      - ✅ [T04 - Implement TypeScript Configuration and Linting](E01/F03/T04/spec.md) `completed`
+      - 📋 [T05 - Create Development Tooling and Generators](E01/F03/T05/spec.md) `draft`
+      - 📋 [T06 - Configure CI/CD Pipeline and Automation](E01/F03/T06/spec.md) `draft`
     
 - 📋 [F04 - CI/CD Pipeline Foundation](E01/F04/spec.md) `draft`
-  - 📋 [T01 - GitHub Actions Workflow Structure Setup](E01/E01-F04/T01/spec.md) `draft`
-      - 📋 [T02 - Main CI Pipeline Configuration](E01/E01-F04/T02/spec.md) `draft`
-      - 📋 [T03 - Security Scanning Workflows](E01/E01-F04/T03/spec.md) `draft`
-      - 📋 [T04 - Deployment Pipeline Workflows](E01/E01-F04/T04/spec.md) `draft`
-      - 📋 [T05 - Docker Multi-stage Build Configuration](E01/E01-F04/T05/spec.md) `draft`
-      - 📋 [T06 - Docker Compose CI Testing Environment](E01/E01-F04/T06/spec.md) `draft`
-      - 📋 [T07 - Test Automation and Coverage Configuration](E01/E01-F04/T07/spec.md) `draft`
-      - 📋 [T08 - Performance Testing Workflow](E01/E01-F04/T08/spec.md) `draft`
-      - 📋 [T09 - Release Management and Semantic Versioning](E01/E01-F04/T09/spec.md) `draft`
-      - 📋 [T10 - Branch Protection and Quality Gates](E01/E01-F04/T10/spec.md) `draft`
-      - 📋 [T11 - CI/CD Monitoring and Notifications](E01/E01-F04/T11/spec.md) `draft`
+  - 📋 [T01 - GitHub Actions Workflow Structure Setup](E01/F04/T01/spec.md) `draft`
+      - 📋 [T02 - Main CI Pipeline Configuration](E01/F04/T02/spec.md) `draft`
+      - 📋 [T03 - Security Scanning Workflows](E01/F04/T03/spec.md) `draft`
+      - 📋 [T04 - Deployment Pipeline Workflows](E01/F04/T04/spec.md) `draft`
+      - 📋 [T05 - Docker Multi-stage Build Configuration](E01/F04/T05/spec.md) `draft`
+      - 📋 [T06 - Docker Compose CI Testing Environment](E01/F04/T06/spec.md) `draft`
+      - 📋 [T07 - Test Automation and Coverage Configuration](E01/F04/T07/spec.md) `draft`
+      - 📋 [T08 - Performance Testing Workflow](E01/F04/T08/spec.md) `draft`
+      - 📋 [T09 - Release Management and Semantic Versioning](E01/F04/T09/spec.md) `draft`
+      - 📋 [T10 - Branch Protection and Quality Gates](E01/F04/T10/spec.md) `draft`
+      - 📋 [T11 - CI/CD Monitoring and Notifications](E01/F04/T11/spec.md) `draft`
     
 - 📋 [F05 - Database Infrastructure](E01/F05/spec.md) `draft`
 
@@ -105,13 +105,13 @@ Completed: 18/62
 - 📋 [F11 - Real-time Broker Monitoring and Observability](E02/F11/spec.md) `draft`
 
 
-### 📋 [E03 - Market Data Collection &amp; Processing](E03/spec.md)
+### 📋 [E03 - Market Data Collection & Processing](E03/spec.md)
 
 > Status: `draft` | Priority: `high`
 
 
 
-### 📋 [E04 - Trading Strategy Engine &amp; DSL](E04/spec.md)
+### 📋 [E04 - Trading Strategy Engine & DSL](E04/spec.md)
 
 > Status: `draft` | Priority: `high`
 
@@ -123,19 +123,19 @@ Completed: 18/62
 
 
 
-### 📋 [E06 - Order Execution &amp; Portfolio Management](E06/spec.md)
+### 📋 [E06 - Order Execution & Portfolio Management](E06/spec.md)
 
 > Status: `draft` | Priority: `high`
 
 
 
-### 📋 [E07 - User Interface &amp; Dashboard](E07/spec.md)
+### 📋 [E07 - User Interface & Dashboard](E07/spec.md)
 
 > Status: `draft` | Priority: `medium`
 
 
 
-### 📋 [E08 - Monitoring &amp; Observability](E08/spec.md)
+### 📋 [E08 - Monitoring & Observability](E08/spec.md)
 
 > Status: `draft` | Priority: `high`
 
@@ -153,13 +153,13 @@ Completed: 18/62
 
 
 
-### 📋 [E11 - Performance Optimization &amp; Scaling](E11/spec.md)
+### 📋 [E11 - Performance Optimization & Scaling](E11/spec.md)
 
 > Status: `draft` | Priority: `high`
 
 
 
-### 📋 [E12 - Deployment &amp; DevOps](E12/spec.md)
+### 📋 [E12 - Deployment & DevOps](E12/spec.md)
 
 > Status: `draft` | Priority: `high`
 

--- a/specs/index.md
+++ b/specs/index.md
@@ -29,41 +29,41 @@ Completed: 18/62
 
 - ✅ [F01 - Storage Infrastructure Coordination](E01/F01/spec.md) `completed`
   - ✅ [T01 - Hot Storage (NVMe) Directory Setup](E01/F01/T01/spec.md) `completed`
-      - ✅ [T02 - Database Mount Integration](E01/F01/T02/spec.md) `completed`
-      - ✅ [T03 - Warm Storage (SATA) Setup](E01/F01/T03/spec.md) `completed`
-      - ✅ [T04 - Cold Storage (NAS) Integration](E01/F01/T04/spec.md) `completed`
-      - ✅ [T05 - Storage Performance Optimization](E01/F01/T05/spec.md) `completed`
-      - ✅ [T06 - Tiered Storage Management](E01/F01/T06/spec.md) `completed`
-    
+  - ✅ [T02 - Database Mount Integration](E01/F01/T02/spec.md) `completed`
+  - ✅ [T03 - Warm Storage (SATA) Setup](E01/F01/T03/spec.md) `completed`
+  - ✅ [T04 - Cold Storage (NAS) Integration](E01/F01/T04/spec.md) `completed`
+  - ✅ [T05 - Storage Performance Optimization](E01/F01/T05/spec.md) `completed`
+  - ✅ [T06 - Tiered Storage Management](E01/F01/T06/spec.md) `completed`
+
 - ✅ [F02 - Development Environment Setup](E01/F02/spec.md) `completed`
   - ✅ [T01 - Node.js and Yarn Environment Setup](E01/F02/T01/spec.md) `completed`
-      - ✅ [T02 - VS Code IDE Configuration](E01/F02/T02/spec.md) `completed`
-      - ✅ [T03 - Docker and Database Services Setup](E01/F02/T03/spec.md) `completed`
-      - ✅ [T04 - Environment Configuration and Secrets Management](E01/F02/T04/spec.md) `completed`
-      - ✅ [T05 - Code Quality Tools and Git Hooks](E01/F02/T05/spec.md) `completed`
-      - ✅ [T06 - Development Scripts and Automation](E01/F02/T06/spec.md) `completed`
-    
+  - ✅ [T02 - VS Code IDE Configuration](E01/F02/T02/spec.md) `completed`
+  - ✅ [T03 - Docker and Database Services Setup](E01/F02/T03/spec.md) `completed`
+  - ✅ [T04 - Environment Configuration and Secrets Management](E01/F02/T04/spec.md) `completed`
+  - ✅ [T05 - Code Quality Tools and Git Hooks](E01/F02/T05/spec.md) `completed`
+  - ✅ [T06 - Development Scripts and Automation](E01/F02/T06/spec.md) `completed`
+
 - 🚧 [F03 - Monorepo Structure and Tooling](E01/F03/spec.md) `in_progress`
   - ✅ [T01 - Initialize Nx Workspace with Base Configuration](E01/F03/T01/spec.md) `completed`
-      - ✅ [T02 - Configure Shared Libraries Infrastructure](E01/F03/T02/spec.md) `completed`
-      - ✅ [T03 - Set Up Build and Testing Infrastructure](E01/F03/T03/spec.md) `completed`
-      - ✅ [T04 - Implement TypeScript Configuration and Linting](E01/F03/T04/spec.md) `completed`
-      - 📋 [T05 - Create Development Tooling and Generators](E01/F03/T05/spec.md) `draft`
-      - 📋 [T06 - Configure CI/CD Pipeline and Automation](E01/F03/T06/spec.md) `draft`
-    
+  - ✅ [T02 - Configure Shared Libraries Infrastructure](E01/F03/T02/spec.md) `completed`
+  - ✅ [T03 - Set Up Build and Testing Infrastructure](E01/F03/T03/spec.md) `completed`
+  - ✅ [T04 - Implement TypeScript Configuration and Linting](E01/F03/T04/spec.md) `completed`
+  - 📋 [T05 - Create Development Tooling and Generators](E01/F03/T05/spec.md) `draft`
+  - 📋 [T06 - Configure CI/CD Pipeline and Automation](E01/F03/T06/spec.md) `draft`
+
 - 📋 [F04 - CI/CD Pipeline Foundation](E01/F04/spec.md) `draft`
   - 📋 [T01 - GitHub Actions Workflow Structure Setup](E01/F04/T01/spec.md) `draft`
-      - 📋 [T02 - Main CI Pipeline Configuration](E01/F04/T02/spec.md) `draft`
-      - 📋 [T03 - Security Scanning Workflows](E01/F04/T03/spec.md) `draft`
-      - 📋 [T04 - Deployment Pipeline Workflows](E01/F04/T04/spec.md) `draft`
-      - 📋 [T05 - Docker Multi-stage Build Configuration](E01/F04/T05/spec.md) `draft`
-      - 📋 [T06 - Docker Compose CI Testing Environment](E01/F04/T06/spec.md) `draft`
-      - 📋 [T07 - Test Automation and Coverage Configuration](E01/F04/T07/spec.md) `draft`
-      - 📋 [T08 - Performance Testing Workflow](E01/F04/T08/spec.md) `draft`
-      - 📋 [T09 - Release Management and Semantic Versioning](E01/F04/T09/spec.md) `draft`
-      - 📋 [T10 - Branch Protection and Quality Gates](E01/F04/T10/spec.md) `draft`
-      - 📋 [T11 - CI/CD Monitoring and Notifications](E01/F04/T11/spec.md) `draft`
-    
+  - 📋 [T02 - Main CI Pipeline Configuration](E01/F04/T02/spec.md) `draft`
+  - 📋 [T03 - Security Scanning Workflows](E01/F04/T03/spec.md) `draft`
+  - 📋 [T04 - Deployment Pipeline Workflows](E01/F04/T04/spec.md) `draft`
+  - 📋 [T05 - Docker Multi-stage Build Configuration](E01/F04/T05/spec.md) `draft`
+  - 📋 [T06 - Docker Compose CI Testing Environment](E01/F04/T06/spec.md) `draft`
+  - 📋 [T07 - Test Automation and Coverage Configuration](E01/F04/T07/spec.md) `draft`
+  - 📋 [T08 - Performance Testing Workflow](E01/F04/T08/spec.md) `draft`
+  - 📋 [T09 - Release Management and Semantic Versioning](E01/F04/T09/spec.md) `draft`
+  - 📋 [T10 - Branch Protection and Quality Gates](E01/F04/T10/spec.md) `draft`
+  - 📋 [T11 - CI/CD Monitoring and Notifications](E01/F04/T11/spec.md) `draft`
+
 - 📋 [F05 - Database Infrastructure](E01/F05/spec.md) `draft`
 
 - 📋 [F06 - Message Queue Setup](E01/F06/spec.md) `draft`

--- a/templates/index.template.md
+++ b/templates/index.template.md
@@ -35,13 +35,14 @@ Completed: {{stats.completed.length}}/{{calculated.totalSpecs}}
   {{#each feature.children as |task taskKey|}}
   - {{statusIcon task.status}} [{{taskKey}} - {{{task.title}}}]({{specPath epicKey featureKey taskKey}}/spec.md) `{{task.status}}`
     {{#if task.children}}
-    {{#each task.children as |subtask subtaskKey|}} - {{statusIcon subtask.status}} [{{subtaskKey}} - {{{subtask.title}}}]({{specPath epicKey featureKey taskKey subtaskKey}}/spec.md) `{{subtask.status}}`
+    {{#each task.children as |subtask subtaskKey|}}
+    - {{statusIcon subtask.status}} [{{subtaskKey}} - {{{subtask.title}}}]({{specPath epicKey featureKey taskKey subtaskKey}}/spec.md) `{{subtask.status}}`
     {{/each}}
     {{/if}}
-    {{/each}}
-    {{/if}}
-    {{/each}}
-    {{/if}}
+  {{/each}}
+  {{/if}}
+{{/each}}
+{{/if}}
 
 {{/each}}
 

--- a/templates/index.template.md
+++ b/templates/index.template.md
@@ -21,21 +21,21 @@ Completed: {{stats.completed.length}}/{{calculated.totalSpecs}}
 
 ## 📁 Specifications
 
-{{#each hierarchy}}
+{{#each hierarchy as |epic epicKey|}}
 
-### {{statusIcon status}} [{{@key}} - {{{title}}}]({{@key}}/spec.md)
+### {{statusIcon epic.status}} [{{epicKey}} - {{{epic.title}}}]({{epicKey}}/spec.md)
 
-> Status: `{{status}}` | Priority: `{{priority}}`
+> Status: `{{epic.status}}` | Priority: `{{epic.priority}}`
 
-{{#if children}}
-{{#each children}}
+{{#if epic.children}}
+{{#each epic.children as |feature featureKey|}}
 
-- {{statusIcon status}} [{{@key}} - {{{title}}}]({{specPath ../@key @key}}/spec.md) `{{status}}`
-  {{#if children}}
-  {{#each children}}
-  - {{statusIcon status}} [{{@key}} - {{{title}}}]({{specPath ../../@key ../@key @key}}/spec.md) `{{status}}`
-    {{#if children}}
-    {{#each children}} - {{statusIcon status}} [{{@key}} - {{{title}}}]({{specPath ../../../@key ../../@key ../@key @key}}/spec.md) `{{status}}`
+- {{statusIcon feature.status}} [{{featureKey}} - {{{feature.title}}}]({{specPath epicKey featureKey}}/spec.md) `{{feature.status}}`
+  {{#if feature.children}}
+  {{#each feature.children as |task taskKey|}}
+  - {{statusIcon task.status}} [{{taskKey}} - {{{task.title}}}]({{specPath epicKey featureKey taskKey}}/spec.md) `{{task.status}}`
+    {{#if task.children}}
+    {{#each task.children as |subtask subtaskKey|}} - {{statusIcon subtask.status}} [{{subtaskKey}} - {{{subtask.title}}}]({{specPath epicKey featureKey taskKey subtaskKey}}/spec.md) `{{subtask.status}}`
     {{/each}}
     {{/if}}
     {{/each}}

--- a/templates/index.template.md
+++ b/templates/index.template.md
@@ -30,12 +30,12 @@ Completed: {{stats.completed.length}}/{{calculated.totalSpecs}}
 {{#if children}}
 {{#each children}}
 
-- {{statusIcon status}} [{{@key}} - {{title}}]({{parent}}/{{@key}}/spec.md) `{{status}}`
+- {{statusIcon status}} [{{@key}} - {{title}}]({{../@key}}/{{@key}}/spec.md) `{{status}}`
   {{#if children}}
   {{#each children}}
-  - {{statusIcon status}} [{{@key}} - {{title}}]({{../parent}}/{{parent}}/{{@key}}/spec.md) `{{status}}`
+  - {{statusIcon status}} [{{@key}} - {{title}}]({{../../@key}}/{{../@key}}/{{@key}}/spec.md) `{{status}}`
     {{#if children}}
-    {{#each children}} - {{statusIcon status}} [{{@key}} - {{title}}]({{../../parent}}/{{../parent}}/{{parent}}/{{@key}}/spec.md) `{{status}}`
+    {{#each children}} - {{statusIcon status}} [{{@key}} - {{title}}]({{../../../@key}}/{{../../@key}}/{{../@key}}/{{@key}}/spec.md) `{{status}}`
     {{/each}}
     {{/if}}
     {{/each}}

--- a/templates/index.template.md
+++ b/templates/index.template.md
@@ -23,19 +23,19 @@ Completed: {{stats.completed.length}}/{{calculated.totalSpecs}}
 
 {{#each hierarchy}}
 
-### {{statusIcon status}} [{{@key}} - {{title}}]({{@key}}/spec.md)
+### {{statusIcon status}} [{{@key}} - {{{title}}}]({{@key}}/spec.md)
 
 > Status: `{{status}}` | Priority: `{{priority}}`
 
 {{#if children}}
 {{#each children}}
 
-- {{statusIcon status}} [{{@key}} - {{title}}]({{../@key}}/{{@key}}/spec.md) `{{status}}`
+- {{statusIcon status}} [{{@key}} - {{{title}}}]({{../@key}}/{{@key}}/spec.md) `{{status}}`
   {{#if children}}
   {{#each children}}
-  - {{statusIcon status}} [{{@key}} - {{title}}]({{../../@key}}/{{../@key}}/{{@key}}/spec.md) `{{status}}`
+  - {{statusIcon status}} [{{@key}} - {{{title}}}]({{../../@key}}/{{../@key}}/{{@key}}/spec.md) `{{status}}`
     {{#if children}}
-    {{#each children}} - {{statusIcon status}} [{{@key}} - {{title}}]({{../../../@key}}/{{../../@key}}/{{../@key}}/{{@key}}/spec.md) `{{status}}`
+    {{#each children}} - {{statusIcon status}} [{{@key}} - {{{title}}}]({{../../../@key}}/{{../../@key}}/{{../@key}}/{{@key}}/spec.md) `{{status}}`
     {{/each}}
     {{/if}}
     {{/each}}

--- a/templates/index.template.md
+++ b/templates/index.template.md
@@ -30,12 +30,12 @@ Completed: {{stats.completed.length}}/{{calculated.totalSpecs}}
 {{#if children}}
 {{#each children}}
 
-- {{statusIcon status}} [{{@key}} - {{{title}}}]({{../@key}}/{{@key}}/spec.md) `{{status}}`
+- {{statusIcon status}} [{{@key}} - {{{title}}}]({{specPath ../@key @key}}/spec.md) `{{status}}`
   {{#if children}}
   {{#each children}}
-  - {{statusIcon status}} [{{@key}} - {{{title}}}]({{../../@key}}/{{../@key}}/{{@key}}/spec.md) `{{status}}`
+  - {{statusIcon status}} [{{@key}} - {{{title}}}]({{specPath ../../@key ../@key @key}}/spec.md) `{{status}}`
     {{#if children}}
-    {{#each children}} - {{statusIcon status}} [{{@key}} - {{{title}}}]({{../../../@key}}/{{../../@key}}/{{../@key}}/{{@key}}/spec.md) `{{status}}`
+    {{#each children}} - {{statusIcon status}} [{{@key}} - {{{title}}}]({{specPath ../../../@key ../../@key ../@key @key}}/spec.md) `{{status}}`
     {{/each}}
     {{/if}}
     {{/each}}


### PR DESCRIPTION
## Summary
- Fixed incorrect hierarchical paths in `specs/index.md` (was `E01/E01-F01/T01`, now correctly `E01/F01/T01`)
- Resolved HTML entity encoding issue where `&` appeared as `&amp;` in spec titles
- Corrected task indentation to show T01-T06 as siblings rather than nested under T01

## Technical Details
- Added `specPath` helper function in `generate-index.ts` to properly build file paths from hierarchical keys
- Updated `index.template.md` to use Handlebars named variables (`as |epic epicKey|`) for proper scope access
- Used triple braces `{{{title}}}` to prevent HTML escaping of ampersands
- Fixed template indentation to ensure tasks are rendered as siblings under features

## Changes Made
1. **Path Generation Fix**: Modified template to use parent directory keys instead of `parent` field
2. **HTML Encoding Fix**: Changed from `{{title}}` to `{{{title}}}` to prevent escaping
3. **Indentation Fix**: Adjusted `{{#each}}` block placement to maintain proper hierarchy levels

## Testing
- Run `yarn run parse:specs` to parse spec files
- Run `yarn run generate:index` to regenerate `specs/index.md`
- Verify paths follow structure: `E01/F01/T01/spec.md`
- Confirm no `&amp;` entities appear in titles
- Check that all tasks under a feature have same indentation level

## Breaking Changes
None - These are display-only fixes that don't affect spec structure or functionality