### PR TITLE
fix(ci): update all GitHub Actions workflows to use Yarn instead of npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: 'yarn'
 
       - name: Cache Nx
         uses: actions/cache@v3
@@ -60,7 +60,7 @@ jobs:
             ${{ runner.os }}-nx-
 
       - name: Install Dependencies
-        run: npm ci --prefer-offline --no-audit
+        run: yarn install --immutable
 
       - name: Calculate Affected
         id: affected
@@ -107,7 +107,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: 'yarn'
 
       - name: Restore Nx Cache
         uses: actions/cache@v3
@@ -118,7 +118,7 @@ jobs:
             ${{ runner.os }}-nx-
 
       - name: Install Dependencies
-        run: npm ci --prefer-offline --no-audit
+        run: yarn install --immutable
 
       - name: Run Lint
         run: npx nx affected --target=lint --base=${{ github.event.pull_request.base.sha || 'HEAD~1' }} --parallel=3
@@ -138,7 +138,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: 'yarn'
 
       - name: Restore Nx Cache
         uses: actions/cache@v3
@@ -149,7 +149,7 @@ jobs:
             ${{ runner.os }}-nx-
 
       - name: Install Dependencies
-        run: npm ci --prefer-offline --no-audit
+        run: yarn install --immutable
 
       - name: Run Type Check
         run: npx nx affected --target=type-check --base=${{ github.event.pull_request.base.sha || 'HEAD~1' }} --parallel=3
@@ -172,7 +172,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: 'yarn'
 
       - name: Restore Nx Cache
         uses: actions/cache@v3
@@ -183,7 +183,7 @@ jobs:
             ${{ runner.os }}-nx-
 
       - name: Install Dependencies
-        run: npm ci --prefer-offline --no-audit
+        run: yarn install --immutable
 
       - name: Run Tests
         run: npx nx affected --target=test --base=${{ github.event.pull_request.base.sha || 'HEAD~1' }} --parallel=3 --configuration=ci --coverage
@@ -214,7 +214,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: 'yarn'
 
       - name: Restore Nx Cache
         uses: actions/cache@v3
@@ -225,7 +225,7 @@ jobs:
             ${{ runner.os }}-nx-
 
       - name: Install Dependencies
-        run: npm ci --prefer-offline --no-audit
+        run: yarn install --immutable
 
       - name: Build Affected
         run: npx nx affected --target=build --base=${{ github.event.pull_request.base.sha || 'HEAD~1' }} --parallel=3 --configuration=production

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -42,15 +42,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          cache: 'npm'
+          cache: 'yarn'
 
       - name: Install Dependencies
-        run: npm ci --prefer-offline --no-audit
+        run: yarn install --immutable
 
       - name: Run Tests with Coverage
         run: |
           # Generate coverage reports for SonarCloud
-          npm run test:coverage || true
+          yarn test:coverage || true
           
           # Find and display coverage summary
           if [ -f "coverage/lcov.info" ]; then
@@ -105,16 +105,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          cache: 'npm'
+          cache: 'yarn'
 
       - name: Install Dependencies
-        run: npm ci --prefer-offline --no-audit
+        run: yarn install --immutable
 
       # CodeQL analyzes the code built by your build system
       - name: Build Code for Analysis
         run: |
           # Build all projects for comprehensive analysis
-          npm run build || true
+          yarn build || true
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
@@ -138,10 +138,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          cache: 'npm'
+          cache: 'yarn'
 
       - name: Install Dependencies
-        run: npm ci --prefer-offline --no-audit
+        run: yarn install --immutable
 
       - name: Check Code Complexity
         run: |
@@ -168,7 +168,7 @@ jobs:
         run: |
           # Run npm audit for known vulnerabilities
           echo "::group::Security Audit"
-          npm audit --audit-level=moderate || true
+          yarn npm audit --audit-level=moderate || true
           echo "::endgroup::"
 
   # ═══════════════════════════════════════════════════════════════════

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,10 +94,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: 'yarn'
 
       - name: Install Dependencies
-        run: npm ci --prefer-offline --no-audit
+        run: yarn install --immutable
 
       - name: Build Service
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,16 +57,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          cache: 'npm'
+          cache: 'yarn'
 
       - name: Install Dependencies
-        run: npm ci --prefer-offline --no-audit
+        run: yarn install --immutable
 
       - name: Build All Projects
         run: |
           # Build all projects for release
           echo "📦 Building all projects for release..."
-          npm run build:all || npm run build || npx nx run-many --target=build --all
+          yarn build:all || yarn build || npx nx run-many --target=build --all
           
           # Verify dist folder exists
           if [ -d "dist" ]; then
@@ -80,7 +80,7 @@ jobs:
         run: |
           # Ensure all tests pass before release
           echo "🧪 Running tests before release..."
-          npm run test:ci || npm test || npx nx run-many --target=test --all --configuration=ci
+          yarn test:ci || yarn test || npx nx run-many --target=test --all --configuration=ci
 
       - name: Semantic Release
         id: semantic
@@ -137,7 +137,7 @@ jobs:
               [
                 "@semantic-release/git",
                 {
-                  "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
+                  "assets": ["CHANGELOG.md", "package.json", "yarn.lock"],
                   "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
                 }
               ]
@@ -146,8 +146,8 @@ jobs:
           EOF
           
           # Install semantic-release if not present
-          if ! npm ls semantic-release &>/dev/null; then
-            npm install --save-dev semantic-release \
+          if ! yarn list --pattern semantic-release &>/dev/null; then
+            yarn add --dev semantic-release \
               @semantic-release/changelog \
               @semantic-release/git \
               @semantic-release/github \


### PR DESCRIPTION
## Summary
- Fixed all GitHub Actions workflow failures by updating package manager from npm to Yarn
- Resolved CI/CD pipeline errors that occurred when merging branches to main
- Updated 4 workflow files to use correct Yarn commands and caching

## Technical Details
- Updated `ci.yml`, `code-quality.yml`, `deploy.yml`, and `release.yml` workflows
- Changed Node.js setup cache from `npm` to `yarn` in all workflows
- Replaced `npm ci --prefer-offline --no-audit` with `yarn install --immutable`
- Updated build/test commands from `npm run` to `yarn` equivalents
- Fixed semantic-release configuration to track `yarn.lock` instead of `package-lock.json`
- Updated audit command to use `yarn npm audit --audit-level=moderate`

## Root Cause
The project uses Yarn 4.9.4 as specified in `package.json` with a `yarn.lock` file, but all GitHub Actions workflows were attempting to use `npm ci` which requires `package-lock.json`. This mismatch caused all CI runs to fail with "npm ci command can only install with an existing package-lock.json" errors.

## Testing
- All workflow files have been updated consistently
- The `generate-index-and-notify.yml` workflow was already correctly using Yarn
- Workflows should now execute successfully on merge to main

## Breaking Changes
None - this is purely a CI/CD configuration fix with no impact on application code.