### PR TITLE
fix(ci): remove invalid secrets reference in Discord notification conditional

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -142,7 +142,7 @@ jobs:
       # ═══════════════════════════════════════════════════════════════
       
       - name: 🎮 Send Discord Notification
-        if: inputs.notify-discord && secrets.DISCORD_WEBHOOK_URL != ''
+        if: inputs.notify-discord
         run: |
           # Send notification to Discord using webhook
           curl -H "Content-Type: application/json" \


### PR DESCRIPTION
- Remove `secrets.DISCORD_WEBHOOK_URL` check from `notify.yml` line 145
- Secrets context not available in job-level conditionals for reusable workflows