### PR TITLE
fix(ci): add install-deps to e2e job setup to enable Corepack

### DIFF
--- a/.github/workflows/ci-improved.yml
+++ b/.github/workflows/ci-improved.yml
@@ -235,6 +235,7 @@ jobs:
         uses: ./.github/actions/setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
+          install-deps: true
           
       - name: Download Build Artifacts
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Ensures Yarn 4.9.4 is properly activated via Corepack before running yarn commands in the e2e job