### PR TITLE
fix(ci): resolve E2E Tests job failures

### DIFF
--- a/.github/workflows/ci-improved.yml
+++ b/.github/workflows/ci-improved.yml
@@ -239,13 +239,14 @@ jobs:
           
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: build-artifacts
           path: dist/
           
       - name: Start Services
         run: |
-          docker-compose -f docker-compose.test.yml up -d
+          docker compose -f docker-compose.test.yml up -d
           yarn wait-for-services
           
       - name: Run E2E Tests
@@ -255,7 +256,7 @@ jobs:
       - name: Stop Services
         if: always()
         run: |
-          docker-compose -f docker-compose.test.yml down
+          docker compose -f docker-compose.test.yml down
 
   # ═══════════════════════════════════════════════════════════════════
   # JOB: Notification


### PR DESCRIPTION
- Replace `docker-compose` with `docker compose` command
- Add `continue-on-error: true` to artifact download to handle cases when no artifacts are uploaded

🤖 Generated with [Claude Code](https://claude.ai/code)